### PR TITLE
Test Plone 6 without checkouts.

### DIFF
--- a/test-6.0.x.cfg
+++ b/test-6.0.x.cfg
@@ -1,53 +1,24 @@
 [buildout]
 extends =
-    https://raw.githubusercontent.com/plone/buildout.coredev/6.0/sources.cfg
-    https://raw.githubusercontent.com/plone/buildout.coredev/6.0/checkouts.cfg
-    https://raw.githubusercontent.com/plone/buildout.coredev/6.0/versions.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-6.0.x.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
 
-parts =
-    instance
-    test
-    code-analysis
-    createcoverage
-
-extensions = mr.developer
-versions = versions
 package-name = plone.app.tiles
 package-extras = [test]
-test-eggs =
-develop = .
-
-[instance]
-recipe = plone.recipe.zope2instance
-user = ${buildout:plone-user}
-wsgi = on
-eggs =
-    Plone
-    plone.app.upgrade
-    ${buildout:package-name}
-    ${buildout:eggs}
-deprecation-warnings = on
-environment-vars =
-    zope_i18n_compile_mo_files true
-zcml =
-    ${buildout:package-name}
-
-[test]
-recipe = zc.recipe.testrunner
-defaults = ['-s', '${buildout:package-name}', '--auto-color', '--auto-progress']
-eggs =
-    Plone
-    plone.app.upgrade
-    ${buildout:package-name} ${buildout:package-extras}
-    ${buildout:test-eggs}
+package-min-coverage = 80
+parts+=
+    createcoverage
+    coverage-sh
+    code-analysis
 
 [code-analysis]
-directory= ${buildout:directory}/plone/app/tiles
-flake8-ignore = E501,E241
+directory = plone
+# E203 Whitespace before ':' (false positives when using black)
+# E231 missing whitespace after ',' (conflicts with black)
+# E501 line too long
+# W503 Line break occurred before a binary operator [outdated]
+flake8-ignore = E203,E231,E501,W503
 
 [versions]
+# plone.app.tiles is pinned in core, so we must unpin it here.
 plone.app.tiles =
-setuptools =
-zc.buildout =
-coverage = >=3.7
-plone.app.robotframework = 1.5.0


### PR DESCRIPTION
Main reason: when running `tox` on all environments, you get more than 3 GB in the `.tox` directory due to the checkouts.
buildout.plonetest has support for testing Plone 6 since a few months.

I copied `test-5.2.x.cfg` over `test-6.0.x.cfg` and made small adjustments.