### PR TITLE
Fix getting original image in images/download/display-file view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog
 3.2.4 (unreleased)
 ------------------
 
+Features:
+
+- Define ``download`` and ``display-file`` views that work for tiles.
+  The original views in ``plone.namedfile`` cannot find the tile data.
+  [maurits]
+
+Bug fixes:
+
 - Fixed getting original image from tile.
   Until now, the ``images`` view tried to get the field from the tile instead of the tile data.
   This only worked when you had explicitly added a property with this field name on the tile.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 3.2.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed getting original image from tile.
+  Until now, the ``images`` view tried to get the field from the tile instead of the tile data.
+  This only worked when you had explicitly added a property with this field name on the tile.
+  [maurits]
 
 
 3.2.3 (2022-01-28)

--- a/plone/app/tiles/browser/configure.zcml
+++ b/plone/app/tiles/browser/configure.zcml
@@ -3,6 +3,20 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="plone.app.tiles">
 
+    <browser:page
+        name="download"
+        for="plone.tiles.interfaces.IPersistentTile"
+        class=".download.Download"
+        permission="zope2.View"
+        />
+
+    <browser:page
+        name="display-file"
+        for="plone.tiles.interfaces.IPersistentTile"
+        class=".download.DisplayFile"
+        permission="zope2.View"
+        />
+
     <!-- Layout -->
     <browser:page
         for="*"

--- a/plone/app/tiles/browser/download.py
+++ b/plone/app/tiles/browser/download.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from AccessControl import Unauthorized
+from plone.namedfile.browser import Download as NamedfileDownload
+from plone.namedfile.browser import DisplayFile as NamedfileDisplayFile
+from AccessControl.ZopeGuards import guarded_getattr
+from AccessControl.ZopeGuards import guarded_getitem
+from plone.namedfile.utils import set_headers
+from plone.namedfile.utils import stream_data
+from plone.rfc822.interfaces import IPrimaryFieldInfo
+from Products.Five.browser import BrowserView
+from zope.annotation.interfaces import IAnnotations
+from zope.interface import implementer
+from zope.publisher.interfaces import IPublishTraverse
+from zope.publisher.interfaces import NotFound
+from ZPublisher.HTTPRangeSupport import expandRanges
+from ZPublisher.HTTPRangeSupport import parseRange
+
+import os
+
+
+@implementer(IPublishTraverse)
+class Download(NamedfileDownload):
+    """Download a file, via ../context/@@download/fieldname/filename
+
+    `fieldname` is the name of an attribute on the context that contains
+    the file. `filename` is the filename that the browser will be told to
+    give the file. If not given, it will be looked up from the field.
+
+    The attribute under `fieldname` should contain a named (blob) file/image
+    instance from this package.
+
+    If no `fieldname` is supplied, then a default field is looked up through
+    adaption to `plone.rfc822.interfaces.IPrimaryFieldInfo`.
+    """
+
+    def _getFile(self):
+        if not self.fieldname:
+            info = IPrimaryFieldInfo(self.context, None)
+            if info is None:
+                # Ensure that we have at least a fieldname
+                raise NotFound(self, '', self.request)
+            self.fieldname = info.fieldname
+
+            # respect field level security as defined in plone.autoform
+            # check if attribute access would be allowed!
+            try:
+                guarded_getitem(self.context.data, self.fieldname)
+            except KeyError:
+                guarded_getattr(self.context, self.fieldname, None)
+
+            file = info.value
+        else:
+            context = getattr(self.context, 'aq_explicit', self.context)
+            try:
+                file = guarded_getitem(context.data, self.fieldname)
+            except KeyError:
+                file = None
+            if file is None:
+                file = guarded_getattr(context, self.fieldname, None)
+
+        if file is None:
+            raise NotFound(self, self.fieldname, self.request)
+
+        return file
+
+
+class DisplayFile(NamedfileDisplayFile):
+    """Display a file, via ../context/@@display-file/fieldname/filename
+
+    Same as Download, however in this case we don't set the filename so the
+    browser can decide to display the file instead.
+
+    For tiles, this needs to combine our Download class above
+    with the NamedfileDisplayFile class.
+    """
+    _getFile = Download._getFile

--- a/plone/app/tiles/demo.py
+++ b/plone/app/tiles/demo.py
@@ -23,6 +23,7 @@ class IPersistentTileData(Interface):
     message = schema.TextLine(title=u"Persisted message")
     counter = schema.Int(title=u"Counter")
     image = NamedImage(title=u"Image", required=False)
+    image2 = NamedImage(title=u"Image2", required=False)
 
     fieldset("counter", label=u"Counter", fields=["counter"])
 
@@ -35,6 +36,9 @@ class PersistentTile(tiles.PersistentTile):
 
     @property
     def image(self):
+        # Explicitly define an image property to ease getting the original.
+        # Note that we only do this for the first image, not the second,
+        # so we can try out multiple ways of getting an image.
         return self.data["image"]
 
     def __call__(self):

--- a/plone/app/tiles/imagescaling.py
+++ b/plone/app/tiles/imagescaling.py
@@ -98,7 +98,10 @@ class ImageScaling(BaseImageScaling):
             # otherwise `name` must refer to a field...
             if "." in name:
                 name, ext = name.rsplit(".", 1)
-            value = getattr(self.context, name)
+            try:
+                value = getattr(self.context, name)
+            except AttributeError:
+                value = self.context.data[name]
             scale_view = ImageScale(
                 self.context, self.request, data=value, fieldname=name
             )

--- a/plone/app/tiles/tests/test_forms.py
+++ b/plone/app/tiles/tests/test_forms.py
@@ -8,7 +8,6 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.tiles.browser.base import TileForm
 from plone.app.tiles.browser.edit import DefaultEditForm
 from plone.app.tiles.testing import PLONE_APP_TILES_FUNCTIONAL_TESTING
-from plone.testing.z2 import Browser
 from plone.tiles.interfaces import ITileType
 from z3c.form.datamanager import DictionaryField
 from z3c.form.interfaces import NOT_CHANGED
@@ -21,6 +20,11 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
+try:
+    from plone.testing.zope import Browser
+except ImportError:
+    # BBB Plone 5.1
+    from plone.testing.z2 import Browser
 
 
 class WrappedEditForm(DefaultEditForm):
@@ -97,7 +101,7 @@ class TestTileDrafting(unittest.TestCase):
             self.browser.getControl(label="Save").click()
 
             # Set should have been called three times, once for each field
-            self.assertEqual(SetCountingDataManager.set_called, 3)
+            self.assertEqual(SetCountingDataManager.set_called, 4)
 
             SetCountingDataManager.set_called = 0
             url = self.browser.url.replace("@@", "@@edit-tile/")
@@ -108,7 +112,7 @@ class TestTileDrafting(unittest.TestCase):
 
             # Should have been called twice now,
             # because the counter field has not changed.
-            self.assertEqual(SetCountingDataManager.set_called, 2)
+            self.assertEqual(SetCountingDataManager.set_called, 3)
         finally:
             # Make sure our useless data manager gets deregistered so it
             # doesn't break everything
@@ -134,7 +138,7 @@ class TestTileDrafting(unittest.TestCase):
         # Comparing two dicts is apparently not done in Python 3.  So we split.
         self.assertListEqual(
             sorted(list(content.keys())),
-            sorted(["message", "counter", "image"]),
+            sorted(["message", "counter", "image", "image2"]),
         )
         self.assertIsNone(content["message"])
         self.assertIsNone(content["counter"])
@@ -148,7 +152,7 @@ class TestTileDrafting(unittest.TestCase):
         # Comparing two dicts is apparently not done in Python 3.  So we split.
         self.assertListEqual(
             sorted(list(content.keys())),
-            sorted(["message", "counter", "image"]),
+            sorted(["message", "counter", "image", "image2"]),
         )
         self.assertEqual(content["message"], "hello")
         self.assertEqual(content["counter"], 1)
@@ -163,7 +167,7 @@ class TestTileDrafting(unittest.TestCase):
         content = form.getContent()
         self.assertListEqual(
             sorted(list(content.keys())),
-            sorted(["message", "counter", "image"]),
+            sorted(["message", "counter", "image", "image2"]),
         )
         self.assertEqual(content["message"], "hello")
         self.assertEqual(content["counter"], 2)
@@ -175,7 +179,7 @@ class TestTileDrafting(unittest.TestCase):
         content = form.getContent()
         self.assertListEqual(
             sorted(list(content.keys())),
-            sorted(["message", "counter", "image"]),
+            sorted(["message", "counter", "image", "image2"]),
         )
         self.assertEqual(content["message"], "bye")
         self.assertEqual(content["counter"], 2)

--- a/plone/app/tiles/tests/test_imagescaling.py
+++ b/plone/app/tiles/tests/test_imagescaling.py
@@ -2,14 +2,24 @@
 from DateTime import DateTime
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
 from plone.app.tiles.demo import PersistentTile
+from plone.app.tiles.testing import PLONE_APP_TILES_FUNCTIONAL_TESTING
 from plone.app.tiles.testing import PLONE_APP_TILES_INTEGRATION_TESTING
 from plone.namedfile.file import NamedImage
 from plone.namedfile.tests import getFile
 from plone.tiles.interfaces import ITileDataManager
 
 import six
+import transaction
 import unittest
+
+try:
+    from plone.testing.zope import Browser
+except ImportError:
+    # BBB Plone 5.1
+    from plone.testing.z2 import Browser
 
 
 class MockNamedImage(NamedImage):
@@ -17,8 +27,7 @@ class MockNamedImage(NamedImage):
 
 
 class TestImageScaling(unittest.TestCase):
-
-    layer = PLONE_APP_TILES_INTEGRATION_TESTING
+    layer = PLONE_APP_TILES_FUNCTIONAL_TESTING
 
     def setUp(self):
         self.portal = self.layer["portal"]
@@ -32,18 +41,31 @@ class TestImageScaling(unittest.TestCase):
                 "Manager",
             ],
         )
-
-    def testImageScaling(self):
-        tile = PersistentTile(self.portal, self.request)
-        tile.id = "mytile"
+        self.tile = PersistentTile(self.portal, self.request)
+        self.tile.id = "mytile"
         data = getFile("image.png")
         data = {
             "message": u"foo",
             "image": MockNamedImage(data, "image/png", u"image.png"),
+            "image2": MockNamedImage(data, "image/png", u"image.png"),
         }
-        dm = ITileDataManager(tile)
+        dm = ITileDataManager(self.tile)
         dm.set(data)
+        transaction.commit()
 
+        app = self.layer["app"]
+        self.browser = Browser(app)
+        self.browser.handleErrors = False
+        self.browser.addHeader(
+            "Authorization",
+            "Basic {0}:{1}".format(
+                TEST_USER_NAME,
+                TEST_USER_PASSWORD,
+            ),
+        )
+        self.base_url = self.portal.absolute_url() + "/@@plone.app.tiles.demo.persistent/mytile"
+
+    def testImageScaling(self):
         images = self.portal.restrictedTraverse(
             "@@plone.app.tiles.demo.persistent/mytile/@@images"
         )
@@ -52,12 +74,14 @@ class TestImageScaling(unittest.TestCase):
         else:
             assertRegex = self.assertRegex
 
+        # Test the tag method.
         assertRegex(
             images.tag("image", width=10),
             r'<img src="http://nohost/plone/@@plone.app.tiles.demo.persistent/mytile/@@images/[a-z0-9-]+\.png" '
             r'alt="foo" title="foo" height="10" width="10" />',
         )
 
+        # Test the scale method.
         scale = images.scale("image", scale="mini")
         self.assertEqual(scale.data.data[:4], b"\x89PNG")
         self.assertEqual(scale.data.getImageSize(), (200, 200))
@@ -65,3 +89,35 @@ class TestImageScaling(unittest.TestCase):
             scale.url,
             r"http://nohost/plone/@@plone.app.tiles.demo.persistent/mytile/@@images/[a-z0-9-]+\.png",
         )
+        transaction.commit()
+
+        # Visit the unique scale in the browser.
+        self.browser.open(scale.url)
+        self.assertEqual(self.browser.contents, scale.data.data)
+
+        # Visit the general scale in the browser.
+        self.browser.open(self.base_url + "/@@images/image/mini")
+        self.assertEqual(self.browser.contents, scale.data.data)
+
+    def test_browse_scale(self):
+        self.browser.open(self.base_url + "/@@images/image/thumb")
+
+    def test_browse_original_with_property(self):
+        # On the tile we have explicitly defined an image property,
+        # which is why the following has always worked.
+        self.browser.open(self.base_url + "/@@images/image")
+        orig = getFile("image.png")
+        if hasattr(orig, "read"):
+            # BBB Plone 5.1: it is an open file, not bytes.
+            orig = orig.read()
+        self.assertEqual(self.browser.contents, orig)
+
+    def test_browse_original_without_property(self):
+        # For the second image we have *not* explicitly defined an image property
+        # on the tile, so getting the original failed for a long time.
+        self.browser.open(self.base_url + "/@@images/image2")
+        orig = getFile("image.png")
+        if hasattr(orig, "read"):
+            # BBB Plone 5.1: it is an open file, not bytes.
+            orig = orig.read()
+        self.assertEqual(self.browser.contents, orig)

--- a/plone/app/tiles/tests/test_imagescaling.py
+++ b/plone/app/tiles/tests/test_imagescaling.py
@@ -121,3 +121,36 @@ class TestImageScaling(unittest.TestCase):
             # BBB Plone 5.1: it is an open file, not bytes.
             orig = orig.read()
         self.assertEqual(self.browser.contents, orig)
+
+    def test_download_original_with_property(self):
+        # On the tile we have explicitly defined an image property.
+        self.browser.open(self.base_url + "/@@download/image")
+        orig = getFile("image.png")
+        if hasattr(orig, "read"):
+            # BBB Plone 5.1: it is an open file, not bytes.
+            orig = orig.read()
+        self.assertEqual(self.browser.contents, orig)
+
+    def test_download_original_without_property(self):
+        self.browser.open(self.base_url + "/@@download/image2")
+        orig = getFile("image.png")
+        if hasattr(orig, "read"):
+            # BBB Plone 5.1: it is an open file, not bytes.
+            orig = orig.read()
+        self.assertEqual(self.browser.contents, orig)
+
+    def test_display_file_with_property(self):
+        self.browser.open(self.base_url + "/@@display-file/image")
+        orig = getFile("image.png")
+        if hasattr(orig, "read"):
+            # BBB Plone 5.1: it is an open file, not bytes.
+            orig = orig.read()
+        self.assertEqual(self.browser.contents, orig)
+
+    def test_display_file_without_property(self):
+        self.browser.open(self.base_url + "/@@display-file/image2")
+        orig = getFile("image.png")
+        if hasattr(orig, "read"):
+            # BBB Plone 5.1: it is an open file, not bytes.
+            orig = orig.read()
+        self.assertEqual(self.browser.contents, orig)

--- a/plone/app/tiles/tests/test_lifecycle.py
+++ b/plone/app/tiles/tests/test_lifecycle.py
@@ -2,7 +2,6 @@
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.tiles.testing import PLONE_APP_TILES_FUNCTIONAL_TESTING
-from plone.testing.z2 import Browser
 from plone.tiles.data import ANNOTATIONS_KEY_PREFIX
 from zExceptions import NotFound
 from zope.annotation.interfaces import IAnnotations
@@ -22,6 +21,12 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
+
+try:
+    from plone.testing.zope import Browser
+except ImportError:
+    # BBB Plone 5.1
+    from plone.testing.z2 import Browser
 
 
 class TestTileLifecycle(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ commands_pre =
     plone52: {envbindir}/buildout -Nc {toxinidir}/test-5.2.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
     plone60: {envbindir}/buildout -Nc {toxinidir}/test-6.0.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
 commands =
-    {envbindir}/test
+    {envbindir}/test {posargs:-vc}


### PR DESCRIPTION
Calling `tile/@@images/image/preview` works. But what about getting the original image, with `tile/@@images/image`?
For some custom tiles I have, this does not work, giving a NotFound error.
With the demo tile from `demo.py` this _does_ work. Why? Because it has explicitly defined an [image property](https://github.com/plone/plone.app.tiles/blob/3.2.2/plone/app/tiles/demo.py#L36-L38) and this makes it work. I did not know this was needed, and ideally it should not be. This PR fixes it to work both with and without such a property.

The `@@download` and `@@display-file` views did not work at all, also not for the demo tile. You get an Unauthorized because you are not allowed to access the image property.  I tried fixing this with security declarations, but could not get it to work. This PR registers the two views specifically for persistent tiles, and makes them work by getting the image from the tile data. This works in both cases.
If this fails anyway, we fall back to the original code. I expect this gives an Unauthorized, but maybe someone has a tile where this is setup correctly.

I added tests to cover all uses.

