### PR TITLE
Removed plone.namedfile[blobs] from the test extra.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 3.2.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Removed ``plone.namedfile[blobs]`` from the ``test`` extra.
+  This has been empty since ``plone.namedfile`` 2.0, used since Plone 4.3.0.
+  [maurits]
 
 
 3.2.2 (2021-12-21)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "six",
         "zope.annotation",
         "zope.i18nmessageid",
-        "plone.namedfile",
+        "plone.namedfile >= 2.0",
         "plone.memoize",
         "plone.registry",
         "plone.tiles",
@@ -77,7 +77,6 @@ setup(
             "plone.app.testing",
             "plone.dexterity",
             "plone.app.dexterity",
-            "plone.namedfile[blobs]",
         ],
     },
 )


### PR DESCRIPTION
This has been empty since ``plone.namedfile`` 2.0, used since Plone 4.3.0.
The extra will be removed from plone.namedfile [soon](https://github.com/plone/plone.namedfile/pull/108).