### PR TITLE
Use own storage factory and drop Python 2.7 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,7 @@ jobs:
       matrix:
         config:
         # [Python version, tox env]
-        - ["2.7",   "plone51-py27"]
-        - ["2.7",   "plone52-py27"]
+        - ["3.6",   "plone52-py36"]
         - ["3.7",   "plone52-py37"]
         - ["3.8",   "plone52-py38"]
         - ["3.7",   "plone60-py37"]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 4.0.0a1 (unreleased)
 --------------------
 
+- Register our ``AnnotationStorage`` as ``IImageScaleStorage`` factory.
+  We require ``plone.namedfile >= 6.0.0a2`` for this.
+  Fixes `issue 49 <https://github.com/plone/plone.app.tiles/issues/48>.  [maurits]
+
 - Drop support for Python 2 and Plone 5.1.
   Plone 5.2 and 6.0 are supported, on Python 3.
   See `issue 49 <https://github.com/plone/plone.app.tiles/issues/49>.  [maurits]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,12 @@
 Changelog
 =========
 
-3.3.1 (unreleased)
-------------------
+4.0.0a1 (unreleased)
+--------------------
 
-- Nothing changed yet.
+- Drop support for Python 2 and Plone 5.1.
+  Plone 5.2 and 6.0 are supported, on Python 3.
+  See `issue 49 <https://github.com/plone/plone.app.tiles/issues/49>.  [maurits]
 
 
 3.3.0 (2022-02-04)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 4.0.0a1 (unreleased)
 --------------------
 
+- Register our own ``IImageScaleFactory`` factory for persistent tiles.
+  This fixes scaling images on tiles when the tile does not have the workaround of defining a property for the image field.
+  [maurits]
+
 - Register our ``AnnotationStorage`` as ``IImageScaleStorage`` factory.
   We require ``plone.namedfile >= 6.0.0a2`` for this.
   Fixes `issue 49 <https://github.com/plone/plone.app.tiles/issues/48>.  [maurits]

--- a/base.cfg
+++ b/base.cfg
@@ -1,12 +1,8 @@
 [buildout]
-extends =
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.1.x.cfg
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
-
 package-name = plone.app.tiles
 package-extras = [test]
 package-min-coverage = 80
-parts+=
+parts +=
     createcoverage
     coverage-sh
     code-analysis
@@ -22,5 +18,7 @@ flake8-ignore = E203,E231,E501,W503
 [versions]
 # plone.app.tiles is pinned in core, so we must unpin it here.
 plone.app.tiles =
-setuptools = 41.2.0
-zc.buildout = 2.13.3
+# We need a newer plone.namedfile, and depend on it in setup.py.
+plone.namedfile = 6.0.0a2
+# Newer plone.scale is not strictly needed, but we should test with it.
+plone.scale = 4.0.0a1

--- a/base.cfg
+++ b/base.cfg
@@ -22,3 +22,8 @@ plone.app.tiles =
 plone.namedfile = 6.0.0a2
 # Newer plone.scale is not strictly needed, but we should test with it.
 plone.scale = 4.0.0a1
+
+# Use same zc.buildout and setuptools in all environments.
+# Keep in sync with requirements.txt please.
+setuptools = 59.6.0
+zc.buildout = 3.0.0rc1

--- a/base.cfg
+++ b/base.cfg
@@ -19,7 +19,7 @@ flake8-ignore = E203,E231,E501,W503
 # plone.app.tiles is pinned in core, so we must unpin it here.
 plone.app.tiles =
 # We need a newer plone.namedfile, and depend on it in setup.py.
-plone.namedfile = 6.0.0a2
+plone.namedfile = 6.0.0a3
 # Newer plone.scale is not strictly needed, but we should test with it.
 plone.scale = 4.0.0a1
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,25 +2,4 @@
 extends =
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.x.cfg
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
-
-package-name = plone.app.tiles
-package-extras = [test]
-package-min-coverage = 80
-parts+=
-    createcoverage
-    coverage-sh
-    code-analysis
-
-[code-analysis]
-directory = plone
-# E203 Whitespace before ':' (false positives when using black)
-# E231 missing whitespace after ',' (conflicts with black)
-# E501 line too long
-# W503 Line break occurred before a binary operator [outdated]
-flake8-ignore = E203,E231,E501,W503
-
-[versions]
-# plone.app.tiles is pinned in core, so we must unpin it here.
-plone.app.tiles =
-setuptools = 41.2.0
-zc.buildout = 2.13.3
+    base.cfg

--- a/plone/app/tiles/browser/download.py
+++ b/plone/app/tiles/browser/download.py
@@ -1,22 +1,12 @@
 # -*- coding: utf-8 -*-
-from AccessControl import Unauthorized
 from plone.namedfile.browser import Download as NamedfileDownload
 from plone.namedfile.browser import DisplayFile as NamedfileDisplayFile
 from AccessControl.ZopeGuards import guarded_getattr
 from AccessControl.ZopeGuards import guarded_getitem
-from plone.namedfile.utils import set_headers
-from plone.namedfile.utils import stream_data
 from plone.rfc822.interfaces import IPrimaryFieldInfo
-from Products.Five.browser import BrowserView
-from zope.annotation.interfaces import IAnnotations
 from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
 from zope.publisher.interfaces import NotFound
-from ZPublisher.HTTPRangeSupport import expandRanges
-from ZPublisher.HTTPRangeSupport import parseRange
-
-import os
-
 
 
 def _shared_getFile(tile_view):
@@ -65,7 +55,6 @@ def _shared_getFile(tile_view):
         raise NotFound(tile_view, tile_view.fieldname, tile_view.request)
 
     return file
-
 
 
 @implementer(IPublishTraverse)

--- a/plone/app/tiles/configure.zcml
+++ b/plone/app/tiles/configure.zcml
@@ -43,6 +43,7 @@
 
   <!-- Image scale support for tile images -->
   <adapter factory=".imagescaling.AnnotationStorage" />
+  <adapter factory=".imagescaling.TileImageScalingFactory" />
   <browser:page
     name="images"
     for="plone.tiles.interfaces.IPersistentTile"

--- a/plone/app/tiles/configure.zcml
+++ b/plone/app/tiles/configure.zcml
@@ -42,6 +42,7 @@
   </configure>
 
   <!-- Image scale support for tile images -->
+  <adapter factory=".imagescaling.AnnotationStorage" />
   <browser:page
     name="images"
     for="plone.tiles.interfaces.IPersistentTile"

--- a/plone/app/tiles/imagescaling.py
+++ b/plone/app/tiles/imagescaling.py
@@ -8,14 +8,17 @@ from plone.tiles.interfaces import IPersistentTile
 from plone.namedfile.interfaces import INamedImage
 from plone.namedfile.scaling import ImageScale as BaseImageScale
 from plone.namedfile.scaling import ImageScaling as BaseImageScaling
+from plone.namedfile.scaling import DefaultImageScalingFactory
 from plone.namedfile.utils import set_headers
 from plone.namedfile.utils import stream_data
 from plone.scale.storage import AnnotationStorage as BaseAnnotationStorage
 from plone.scale.storage import IImageScaleStorage
+from plone.scale.interfaces import IImageScaleFactory
 from plone.tiles.interfaces import ITileDataManager
 from zExceptions import Unauthorized
 from zope.component import adapter
 from zope.interface import Interface
+from zope.interface import implementer
 from zope.interface import provider
 
 
@@ -70,6 +73,20 @@ class ImageScale(BaseImageScale):
         # validate access
         set_headers(self.data, self.request.response)
         return stream_data(self.data)
+
+
+@implementer(IImageScaleFactory)
+@adapter(IPersistentTile)
+class TileImageScalingFactory(DefaultImageScalingFactory):
+    def get_original_value(self):
+        return self.context.data.get(self.fieldname)
+
+    def url(self):
+        return "{}/@@{}/{}".format(
+            self.context.context.absolute_url(),
+            self.context.__name__,
+            self.context.id,
+        )
 
 
 class ImageScaling(BaseImageScaling):

--- a/plone/app/tiles/tests/test_imagescaling.py
+++ b/plone/app/tiles/tests/test_imagescaling.py
@@ -6,7 +6,6 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.app.tiles.demo import PersistentTile
 from plone.app.tiles.testing import PLONE_APP_TILES_FUNCTIONAL_TESTING
-from plone.app.tiles.testing import PLONE_APP_TILES_INTEGRATION_TESTING
 from plone.namedfile.file import NamedImage
 from plone.namedfile.tests import getFile
 from plone.tiles.interfaces import ITileDataManager

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-setuptools==41.2.0
-zc.buildout==2.13.3
+# Keep in sync with base.cfg!
+setuptools==59.6.0
+zc.buildout==3.0.0rc1
+wheel==0.37.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Keep in sync with base.cfg!
 setuptools==59.6.0
 zc.buildout==3.0.0rc1
+pip==21.3.1
 wheel==0.37.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = "3.3.1.dev0"
+version = "4.0.0a1.dev0"
 long_description = (
     open("README.rst").read()
     + "\n"
@@ -21,17 +21,15 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Framework :: Plone",
-        "Framework :: Plone :: 4.3",
-        "Framework :: Plone :: 5.1",
         "Framework :: Plone :: 5.2",
         "Framework :: Plone :: 6.0",
         "Framework :: Plone :: Addon",
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules",
@@ -49,7 +47,7 @@ setup(
         "six",
         "zope.annotation",
         "zope.i18nmessageid",
-        "plone.namedfile >= 2.0",
+        "plone.namedfile >= 6.0.0a2",
         "plone.memoize",
         "plone.registry",
         "plone.tiles",
@@ -66,7 +64,7 @@ setup(
         "zope.event",
         "zope.lifecycleevent",
         "zope.schema",
-        "Zope2",
+        "Zope",
         "AccessControl",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "six",
         "zope.annotation",
         "zope.i18nmessageid",
-        "plone.namedfile >= 6.0.0a2",
+        "plone.namedfile >= 6.0.0a3",
         "plone.memoize",
         "plone.registry",
         "plone.tiles",

--- a/test-5.2.x.cfg
+++ b/test-5.2.x.cfg
@@ -2,25 +2,4 @@
 extends =
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.2.x.cfg
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
-
-package-name = plone.app.tiles
-package-extras = [test]
-package-min-coverage = 80
-parts+=
-    createcoverage
-    coverage-sh
-    code-analysis
-
-[code-analysis]
-directory = plone
-# E203 Whitespace before ':' (false positives when using black)
-# E231 missing whitespace after ',' (conflicts with black)
-# E501 line too long
-# W503 Line break occurred before a binary operator [outdated]
-flake8-ignore = E203,E231,E501,W503
-
-[versions]
-# plone.app.tiles is pinned in core, so we must unpin it here.
-plone.app.tiles =
-setuptools = 41.2.0
-zc.buildout = 2.13.3
+    base.cfg

--- a/test-6.0.x.cfg
+++ b/test-6.0.x.cfg
@@ -2,23 +2,4 @@
 extends =
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-6.0.x.cfg
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
-
-package-name = plone.app.tiles
-package-extras = [test]
-package-min-coverage = 80
-parts+=
-    createcoverage
-    coverage-sh
-    code-analysis
-
-[code-analysis]
-directory = plone
-# E203 Whitespace before ':' (false positives when using black)
-# E231 missing whitespace after ',' (conflicts with black)
-# E501 line too long
-# W503 Line break occurred before a binary operator [outdated]
-flake8-ignore = E203,E231,E501,W503
-
-[versions]
-# plone.app.tiles is pinned in core, so we must unpin it here.
-plone.app.tiles =
+    base.cfg

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 minversion = 3.18
 envlist =
-    plone51-py27
-    plone52-py{27,37,38}
+    plone52-py{36,37,38}
     plone60-py{37,38,39}
 
 [testenv]
@@ -12,7 +11,6 @@ skip_install = true
 deps =
     zc.buildout
 commands_pre =
-    plone51: {envbindir}/buildout -Nc {toxinidir}/test-5.1.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
     plone52: {envbindir}/buildout -Nc {toxinidir}/test-5.2.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
     plone60: {envbindir}/buildout -Nc {toxinidir}/test-6.0.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 usedevelop = false
 skip_install = true
 deps =
-    zc.buildout
+    -rrequirements.txt
 commands_pre =
     plone52: {envbindir}/buildout -Nc {toxinidir}/test-5.2.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
     plone60: {envbindir}/buildout -Nc {toxinidir}/test-6.0.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test


### PR DESCRIPTION
We get rid of some code then, using the upstream code from `plone.namedfile` and `plone.scale`, including their improvements from the last few years.
We require the latest alpha release of `plone.namedfile`. I have updated our own version to 4.0.0a1.

A bit more work needed/possible though, so I keep it as draft PR for now.

We could refactor much more code after dropping python 2.7, but I wanted to keep the changes small.