### PR TITLE
Accept a fieldname in get_original_value in our scaling code.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 4.0.0a2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Accept a fieldname in ``get_original_value`` in our scaling code.
+  Needed for recent plone.namedfile versions.
+  [maurits]
 
 
 4.0.0a1 (2022-03-09)

--- a/base.cfg
+++ b/base.cfg
@@ -6,6 +6,18 @@ parts +=
     createcoverage
     coverage-sh
     code-analysis
+extensions = mr.developer
+auto-checkout =
+    plone.scale
+
+[remotes]
+plone = https://github.com/plone
+plone_push = git@github.com:plone
+
+[sources]
+# XXX temporary checkout
+# https://github.com/plone/plone.scale/pull/65
+plone.scale = git ${remotes:plone}/plone.scale.git pushurl=${remotes:plone_push}/plone.scale.git branch=maurits-get-original-value-issue-64
 
 [code-analysis]
 directory = plone

--- a/base.cfg
+++ b/base.cfg
@@ -18,10 +18,6 @@ flake8-ignore = E203,E231,E501,W503
 [versions]
 # plone.app.tiles is pinned in core, so we must unpin it here.
 plone.app.tiles =
-# We need a newer plone.namedfile, and depend on it in setup.py.
-plone.namedfile = 6.0.0a3
-# Newer plone.scale is not strictly needed, but we should test with it.
-plone.scale = 4.0.0a1
 
 # Use same zc.buildout and setuptools in all environments.
 # Keep in sync with requirements.txt please.

--- a/base.cfg
+++ b/base.cfg
@@ -6,18 +6,6 @@ parts +=
     createcoverage
     coverage-sh
     code-analysis
-extensions = mr.developer
-auto-checkout =
-    plone.scale
-
-[remotes]
-plone = https://github.com/plone
-plone_push = git@github.com:plone
-
-[sources]
-# XXX temporary checkout
-# https://github.com/plone/plone.scale/pull/65
-plone.scale = git ${remotes:plone}/plone.scale.git pushurl=${remotes:plone_push}/plone.scale.git branch=maurits-get-original-value-issue-64
 
 [code-analysis]
 directory = plone

--- a/plone/app/tiles/imagescaling.py
+++ b/plone/app/tiles/imagescaling.py
@@ -78,8 +78,10 @@ class ImageScale(BaseImageScale):
 @implementer(IImageScaleFactory)
 @adapter(IPersistentTile)
 class TileImageScalingFactory(DefaultImageScalingFactory):
-    def get_original_value(self):
-        return self.context.data.get(self.fieldname)
+    def get_original_value(self, fieldname=None):
+        fieldname = fieldname or self.fieldname
+        if fieldname is not None:
+            return self.context.data.get(fieldname)
 
     def url(self):
         return "{}/@@{}/{}".format(

--- a/plone/app/tiles/tests/test_imagescaling.py
+++ b/plone/app/tiles/tests/test_imagescaling.py
@@ -58,24 +58,17 @@ class TestImageScaling(unittest.TestCase):
         )
         self.base_url = self.portal.absolute_url() + "/@@plone.app.tiles.demo.persistent/mytile"
 
-    def testImageScalingViaProperty(self):
+    def testImageScalingScaleByNameViaProperty(self):
         # The 'image' field is available as property on the demo tile.
         # This makes the tile enough like a standard context.
         images = self.portal.restrictedTraverse(
             "@@plone.app.tiles.demo.persistent/mytile/@@images"
         )
-
-        # Test the tag method.
-        self.assertRegex(
-            images.tag("image", width=10),
-            r'<img src="http://nohost/plone/@@plone.app.tiles.demo.persistent/mytile/@@images/[a-z0-9-]+\.png" '
-            r'alt="foo" title="foo" height="10" width="10" />',
-        )
-
-        # Test the scale method.
-        scale = images.scale("image", scale="mini")
+        scale = images.scale("image", scale="thumb")
+        self.assertIsNotNone(scale)
         self.assertEqual(scale.data.data[:4], b"\x89PNG")
-        self.assertEqual(scale.data.getImageSize(), (200, 200))
+        # Note: the original image is 200x200.
+        self.assertEqual(scale.data.getImageSize(), (128, 128))
         self.assertRegex(
             scale.url,
             r"http://nohost/plone/@@plone.app.tiles.demo.persistent/mytile/@@images/[a-z0-9-]+\.png",
@@ -87,10 +80,88 @@ class TestImageScaling(unittest.TestCase):
         self.assertEqual(self.browser.contents, scale.data.data)
 
         # Visit the general scale in the browser.
-        self.browser.open(self.base_url + "/@@images/image/mini")
+        self.browser.open(self.base_url + "/@@images/image/thumb")
         self.assertEqual(self.browser.contents, scale.data.data)
 
-    def testImageScalingViaData(self):
+    def testImageScalingScaleByWidthViaProperty(self):
+        # The 'image' field is available as property on the demo tile.
+        # This makes the tile enough like a standard context.
+        images = self.portal.restrictedTraverse(
+            "@@plone.app.tiles.demo.persistent/mytile/@@images"
+        )
+        scale = images.scale("image", width=10)
+        self.assertIsNotNone(scale)
+        self.assertEqual(scale.data.data[:4], b"\x89PNG")
+        # Note: the original image is 200x200.
+        self.assertEqual(scale.data.getImageSize(), (10, 10))
+        self.assertRegex(
+            scale.url,
+            r"http://nohost/plone/@@plone.app.tiles.demo.persistent/mytile/@@images/[a-z0-9-]+\.png",
+        )
+        transaction.commit()
+
+        # Visit the unique scale in the browser.
+        self.browser.open(scale.url)
+        self.assertEqual(self.browser.contents, scale.data.data)
+
+    def testImageScalingTagViaProperty(self):
+        # The 'image' field is available as property on the demo tile.
+        # This makes the tile enough like a standard context.
+        images = self.portal.restrictedTraverse(
+            "@@plone.app.tiles.demo.persistent/mytile/@@images"
+        )
+        self.assertRegex(
+            images.tag("image", width=10),
+            r'<img src="http://nohost/plone/@@plone.app.tiles.demo.persistent/mytile/@@images/[a-z0-9-]+\.png" '
+            r'alt="foo" title="foo" height="10" width="10" />',
+        )
+
+    def testImageScalingScaleByNameViaData(self):
+        # The 'image2' field is NOT available as attribute on the demo tile.
+        # This trips up some of the code in plone.namedfile.
+        images = self.portal.restrictedTraverse(
+            "@@plone.app.tiles.demo.persistent/mytile/@@images"
+        )
+        scale = images.scale("image2", scale="thumb")
+        self.assertIsNotNone(scale)
+        self.assertEqual(scale.data.data[:4], b"\x89PNG")
+        # Note: the original image is 200x200.
+        self.assertEqual(scale.data.getImageSize(), (128, 128))
+        self.assertRegex(
+            scale.url,
+            r"http://nohost/plone/@@plone.app.tiles.demo.persistent/mytile/@@images/[a-z0-9-]+\.png",
+        )
+        transaction.commit()
+
+        # Visit the unique scale in the browser.
+        self.browser.open(scale.url)
+        self.assertEqual(self.browser.contents, scale.data.data)
+
+        # Visit the general scale in the browser.
+        self.browser.open(self.base_url + "/@@images/image2/thumb")
+        self.assertEqual(self.browser.contents, scale.data.data)
+
+    def testImageScalingScaleByWidthViaData(self):
+        # The 'image2' field is NOT available as attribute on the demo tile.
+        # This trips up some of the code in plone.namedfile.
+        images = self.portal.restrictedTraverse(
+            "@@plone.app.tiles.demo.persistent/mytile/@@images"
+        )
+        scale = images.scale("image2", width=10)
+        self.assertIsNotNone(scale)
+        self.assertEqual(scale.data.data[:4], b"\x89PNG")
+        self.assertEqual(scale.data.getImageSize(), (10, 10))
+        self.assertRegex(
+            scale.url,
+            r"http://nohost/plone/@@plone.app.tiles.demo.persistent/mytile/@@images/[a-z0-9-]+\.png",
+        )
+        transaction.commit()
+
+        # Visit the unique scale in the browser.
+        self.browser.open(scale.url)
+        self.assertEqual(self.browser.contents, scale.data.data)
+
+    def testImageScalingTagViaData(self):
         # The 'image2' field is NOT available as attribute on the demo tile.
         # This trips up some of the code in plone.namedfile.
         images = self.portal.restrictedTraverse(
@@ -108,24 +179,6 @@ class TestImageScaling(unittest.TestCase):
             r'<img src="http://nohost/plone/@@plone.app.tiles.demo.persistent/mytile/@@images/[a-z0-9-]+\.png" '
             r'alt="foo" title="foo" height="10" width="10" />',
         )
-
-        # Test the scale method.
-        scale = images.scale("image2", scale="mini")
-        self.assertEqual(scale.data.data[:4], b"\x89PNG")
-        self.assertEqual(scale.data.getImageSize(), (200, 200))
-        self.assertRegex(
-            scale.url,
-            r"http://nohost/plone/@@plone.app.tiles.demo.persistent/mytile/@@images/[a-z0-9-]+\.png",
-        )
-        transaction.commit()
-
-        # Visit the unique scale in the browser.
-        self.browser.open(scale.url)
-        self.assertEqual(self.browser.contents, scale.data.data)
-
-        # Visit the general scale in the browser.
-        self.browser.open(self.base_url + "/@@images/image2/mini")
-        self.assertEqual(self.browser.contents, scale.data.data)
 
     def test_browse_scale(self):
         self.browser.open(self.base_url + "/@@images/image/thumb")

--- a/plone/app/tiles/tests/test_imagescaling.py
+++ b/plone/app/tiles/tests/test_imagescaling.py
@@ -8,17 +8,11 @@ from plone.app.tiles.demo import PersistentTile
 from plone.app.tiles.testing import PLONE_APP_TILES_FUNCTIONAL_TESTING
 from plone.namedfile.file import NamedImage
 from plone.namedfile.tests import getFile
+from plone.testing.zope import Browser
 from plone.tiles.interfaces import ITileDataManager
 
-import six
 import transaction
 import unittest
-
-try:
-    from plone.testing.zope import Browser
-except ImportError:
-    # BBB Plone 5.1
-    from plone.testing.z2 import Browser
 
 
 class MockNamedImage(NamedImage):
@@ -70,13 +64,9 @@ class TestImageScaling(unittest.TestCase):
         images = self.portal.restrictedTraverse(
             "@@plone.app.tiles.demo.persistent/mytile/@@images"
         )
-        if six.PY2:
-            assertRegex = self.assertRegexpMatches
-        else:
-            assertRegex = self.assertRegex
 
         # Test the tag method.
-        assertRegex(
+        self.assertRegex(
             images.tag("image", width=10),
             r'<img src="http://nohost/plone/@@plone.app.tiles.demo.persistent/mytile/@@images/[a-z0-9-]+\.png" '
             r'alt="foo" title="foo" height="10" width="10" />',
@@ -86,7 +76,7 @@ class TestImageScaling(unittest.TestCase):
         scale = images.scale("image", scale="mini")
         self.assertEqual(scale.data.data[:4], b"\x89PNG")
         self.assertEqual(scale.data.getImageSize(), (200, 200))
-        assertRegex(
+        self.assertRegex(
             scale.url,
             r"http://nohost/plone/@@plone.app.tiles.demo.persistent/mytile/@@images/[a-z0-9-]+\.png",
         )
@@ -106,15 +96,14 @@ class TestImageScaling(unittest.TestCase):
         images = self.portal.restrictedTraverse(
             "@@plone.app.tiles.demo.persistent/mytile/@@images"
         )
-        if six.PY2:
-            assertRegex = self.assertRegexpMatches
-        else:
-            assertRegex = self.assertRegex
 
         # Test the tag method.
         tag = images.tag("image2", width=10)
         self.assertTrue(tag)
-        assertRegex(
+        # Note: if this gives the original width and height, this means the
+        # original image was not actually found.  plone.scale may search on the
+        # context instead of the tile.
+        self.assertRegex(
             tag,
             r'<img src="http://nohost/plone/@@plone.app.tiles.demo.persistent/mytile/@@images/[a-z0-9-]+\.png" '
             r'alt="foo" title="foo" height="10" width="10" />',
@@ -124,7 +113,7 @@ class TestImageScaling(unittest.TestCase):
         scale = images.scale("image2", scale="mini")
         self.assertEqual(scale.data.data[:4], b"\x89PNG")
         self.assertEqual(scale.data.getImageSize(), (200, 200))
-        assertRegex(
+        self.assertRegex(
             scale.url,
             r"http://nohost/plone/@@plone.app.tiles.demo.persistent/mytile/@@images/[a-z0-9-]+\.png",
         )
@@ -147,9 +136,6 @@ class TestImageScaling(unittest.TestCase):
         # which is why the following has always worked.
         self.browser.open(self.base_url + "/@@images/image")
         orig = getFile("image.png")
-        if hasattr(orig, "read"):
-            # BBB Plone 5.1: it is an open file, not bytes.
-            orig = orig.read()
         self.assertEqual(self.browser.contents, orig)
 
     def test_browse_original_without_property(self):
@@ -157,40 +143,25 @@ class TestImageScaling(unittest.TestCase):
         # on the tile, so getting the original failed for a long time.
         self.browser.open(self.base_url + "/@@images/image2")
         orig = getFile("image.png")
-        if hasattr(orig, "read"):
-            # BBB Plone 5.1: it is an open file, not bytes.
-            orig = orig.read()
         self.assertEqual(self.browser.contents, orig)
 
     def test_download_original_with_property(self):
         # On the tile we have explicitly defined an image property.
         self.browser.open(self.base_url + "/@@download/image")
         orig = getFile("image.png")
-        if hasattr(orig, "read"):
-            # BBB Plone 5.1: it is an open file, not bytes.
-            orig = orig.read()
         self.assertEqual(self.browser.contents, orig)
 
     def test_download_original_without_property(self):
         self.browser.open(self.base_url + "/@@download/image2")
         orig = getFile("image.png")
-        if hasattr(orig, "read"):
-            # BBB Plone 5.1: it is an open file, not bytes.
-            orig = orig.read()
         self.assertEqual(self.browser.contents, orig)
 
     def test_display_file_with_property(self):
         self.browser.open(self.base_url + "/@@display-file/image")
         orig = getFile("image.png")
-        if hasattr(orig, "read"):
-            # BBB Plone 5.1: it is an open file, not bytes.
-            orig = orig.read()
         self.assertEqual(self.browser.contents, orig)
 
     def test_display_file_without_property(self):
         self.browser.open(self.base_url + "/@@display-file/image2")
         orig = getFile("image.png")
-        if hasattr(orig, "read"):
-            # BBB Plone 5.1: it is an open file, not bytes.
-            orig = orig.read()
         self.assertEqual(self.browser.contents, orig)

--- a/test-5.2.x.cfg
+++ b/test-5.2.x.cfg
@@ -3,3 +3,9 @@ extends =
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.2.x.cfg
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
     base.cfg
+
+[versions]
+# We need a newer plone.namedfile, and depend on it in setup.py.
+plone.namedfile = 6.0.0b2
+# Newer plone.scale is not strictly needed, but we should test with it.
+plone.scale = 4.0.0b1

--- a/test-5.2.x.cfg
+++ b/test-5.2.x.cfg
@@ -8,4 +8,4 @@ extends =
 # We need a newer plone.namedfile, and depend on it in setup.py.
 plone.namedfile = 6.0.0b2
 # Newer plone.scale is not strictly needed, but we should test with it.
-plone.scale = 4.0.0b1
+plone.scale = 4.0.0b3

--- a/test-6.0.x.cfg
+++ b/test-6.0.x.cfg
@@ -3,3 +3,7 @@ extends =
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-6.0.x.cfg
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
     base.cfg
+
+[versions]
+# Temporary override.  We need a newer plone.scale.
+plone.scale = 4.0.0b3


### PR DESCRIPTION
Needed for recent plone.namedfile versions.