### PR TITLE
Register our demo tiles when you explicitly load demo.zcml.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 4.0.0a2 (unreleased)
 --------------------
 
+- Register our demo tiles when you explicitly load ``demo.zcml``.
+  Add them to the list in ``plone.app.tiles`` and ``plone.app.mosaic``.
+  [maurits]
+
 - Accept a fieldname in ``get_original_value`` in our scaling code.
   Needed for recent plone.namedfile versions.
   [maurits]

--- a/plone/app/tiles/configure.zcml
+++ b/plone/app/tiles/configure.zcml
@@ -76,4 +76,7 @@
 
   <subscriber handler=".handlers.notifyModified" />
 
+  <!-- To try out the demo tiles, uncomment this: -->
+  <!-- <include package="plone.app.tiles" file="demo.zcml"/> -->
+
 </configure>

--- a/plone/app/tiles/demo.zcml
+++ b/plone/app/tiles/demo.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="plone.app.tiles">
 
@@ -29,5 +30,12 @@
         permission="zope2.View"
         for="*"
         />
+
+  <genericsetup:registerProfile
+    name="demo"
+    title="Tiles demo"
+    directory="profiles/demo"
+    provides="Products.GenericSetup.interfaces.EXTENSION"
+    />
 
 </configure>

--- a/plone/app/tiles/profiles/demo/metadata.xml
+++ b/plone/app/tiles/profiles/demo/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1</version>
+</metadata>

--- a/plone/app/tiles/profiles/demo/registry/tiles.xml
+++ b/plone/app/tiles/profiles/demo/registry/tiles.xml
@@ -13,7 +13,7 @@
     </value>
   </record>
 
-  <records prefix="plone.app.mosaic.app_tiles.plone.app.tiles.demo.persistent"
+  <records prefix="plone.app.mosaic.app_tiles.plone_app_tiles_demo_persistent"
            interface="plone.app.mosaic.interfaces.ITile">
     <value key="name">plone.app.tiles.demo.persistent</value>
     <value key="label">Demo persistent</value>
@@ -26,7 +26,7 @@
     <value key="weight">40</value>
   </records>
 
-  <records prefix="plone.app.mosaic.app_tiles.plone.app.tiles.demo.transient"
+  <records prefix="plone.app.mosaic.app_tiles.plone_app_tiles_demo_transient"
            interface="plone.app.mosaic.interfaces.ITile">
     <value key="name">plone.app.tiles.demo.transient</value>
     <value key="label">Demo transient</value>

--- a/plone/app/tiles/profiles/demo/registry/tiles.xml
+++ b/plone/app/tiles/profiles/demo/registry/tiles.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<registry>
+
+  <!-- Add our tile to the plone.app.tiles lists -->
+  <record name="plone.app.tiles">
+    <field type="plone.registry.field.List">
+      <title>Tiles</title>
+      <value_type type="plone.registry.field.TextLine" />
+    </field>
+    <value purge="false">
+      <element>plone.app.tiles.demo.persistent</element>
+      <element>plone.app.tiles.demo.transient</element>
+    </value>
+  </record>
+
+  <records prefix="plone.app.mosaic.app_tiles.plone.app.tiles.demo.persistent"
+           interface="plone.app.mosaic.interfaces.ITile">
+    <value key="name">plone.app.tiles.demo.persistent</value>
+    <value key="label">Demo persistent</value>
+    <value key="category">advanced</value>
+    <value key="tile_type">app</value>
+    <value key="read_only">false</value>
+    <value key="settings">true</value>
+    <value key="favorite">false</value>
+    <value key="rich_text">false</value>
+    <value key="weight">40</value>
+  </records>
+
+  <records prefix="plone.app.mosaic.app_tiles.plone.app.tiles.demo.transient"
+           interface="plone.app.mosaic.interfaces.ITile">
+    <value key="name">plone.app.tiles.demo.transient</value>
+    <value key="label">Demo transient</value>
+    <value key="category">advanced</value>
+    <value key="tile_type">app</value>
+    <value key="read_only">false</value>
+    <!-- <value key="settings">true</value> -->
+    <!-- <value key="favorite">false</value> -->
+    <!-- <value key="rich_text">false</value> -->
+    <!-- <value key="weight">30</value> -->
+  </records>
+</registry>


### PR DESCRIPTION
Add them to the list in `plone.app.tiles` and `plone.app.mosaic`.

**Problem: this does not work.** The demo tiles _do_ end up in the registry, but I do not see them in the lists of tiles that I can insert into a Mosaic page when I customise the layout:

<img width="744" alt="Screenshot 2022-07-18 at 14 46 56" src="https://user-images.githubusercontent.com/210587/179514340-24fe0edc-a3fb-4d0e-a08d-36d6fea43ff8.png">

What am I missing?
This is on Plone 6.0.0a6 with checkouts of `plone.app.mosaic`, `plone.staticresources`, `plone.app.tiles`.