### PR TITLE
Use ScalesDict instead of PersistentDict to store scales in persistent tiles.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 4.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use ``ScalesDict`` instead of ``PersistentDict`` to store scales in persistent tiles.
+  This avoids ``plone.protect`` warning about write-on-read.
+  Migrate the storage on-the-fly, just like ``plone.scale`` does.
+  [maurits]
 
 
 4.0.0 (2022-12-02)

--- a/base.cfg
+++ b/base.cfg
@@ -21,5 +21,7 @@ plone.app.tiles =
 
 # Use same zc.buildout and setuptools in all environments.
 # Keep in sync with requirements.txt please.
-setuptools = 59.6.0
-zc.buildout = 3.0.0rc1
+pip = 23.3.1
+setuptools = 65.7.0
+wheel = 0.38.4
+zc.buildout = 3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-setuptools==59.6.0
-zc.buildout==3.0.0rc1
-pip==21.3.1
-wheel==0.37.1
+pip==23.3.1
+setuptools==65.7.0
+wheel==0.38.4
+zc.buildout==3.0.1

--- a/test-5.2.x.cfg
+++ b/test-5.2.x.cfg
@@ -11,3 +11,6 @@ plone.namedfile = 6.2.3
 plone.scale = 4.1.0
 # plone.namedfile needs a newer plone.app.uuid
 plone.app.uuid = 2.2.1
+
+[versions:python37]
+plone.scale = 4.0.1

--- a/test-5.2.x.cfg
+++ b/test-5.2.x.cfg
@@ -6,6 +6,8 @@ extends =
 
 [versions]
 # We need a newer plone.namedfile, and depend on it in setup.py.
-plone.namedfile = 6.0.0b2
+plone.namedfile = 6.2.3
 # Newer plone.scale is not strictly needed, but we should test with it.
-plone.scale = 4.0.0b3
+plone.scale = 4.1.0
+# plone.namedfile needs a newer plone.app.uuid
+plone.app.uuid = 2.2.1

--- a/test-6.0.x.cfg
+++ b/test-6.0.x.cfg
@@ -3,7 +3,3 @@ extends =
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-6.0.x.cfg
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
     base.cfg
-
-[versions]
-# Temporary override.  We need a newer plone.scale.
-plone.scale = 4.0.0b3


### PR DESCRIPTION
I got the ``confirm-action`` page on a Mosaic page with a custom persistent tile with image, after migration from Plone 5.2 to 6.0.

With this PR, our custom storage handles this the same way as in [`plone.scale`](https://github.com/plone/plone.scale/blob/9daa130d54e8d3ff5d7cff214380dccf5b6652b2/plone/scale/storage.py#L173-L188).